### PR TITLE
feat/web-layout: 헤더 및 푸터 레이아웃 구현 완료

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Raleway:wght@100;200;300;400;500;600;700;800;900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans&family=Raleway:wght@100;200;300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"
     />
     <title>Vite + React + TS</title>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Raleway:wght@100;200;300;400;500;600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-icons": "^4.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
+import { Footer } from './components/Footer/Footer'
 import { Header } from './components/Header/Header'
 
 export const App = () => {
   return (
     <>
       <Header />
+      <Footer />
     </>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,9 @@
+import { Header } from './components/Header/Header'
+
 export const App = () => {
-  return <></>
+  return (
+    <>
+      <Header />
+    </>
+  )
 }

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -1,0 +1,45 @@
+.footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+
+  width: 100%;
+  padding: 1.5rem 2rem;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.madeby {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  color: #626265;
+  font-size: 0.9rem;
+  font-weight: 500;
+  font-family: Raleway, sans-serif;
+}
+
+.name-link {
+  all: unset;
+
+  margin: 0 0.5rem;
+  cursor: pointer;
+  text-decoration: underline;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', sans-serif;
+}
+
+.name-link:hover {
+  color: rebeccapurple;
+  transition: color 0.3s cubic-bezier(0.2, 0, 0, 1);
+}
+
+.dot {
+  background-color: #525255;
+  width: 0.2rem;
+  height: 0.2rem;
+  border-radius: 50%;
+  line-height: 1;
+}

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -9,6 +9,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
+  z-index: 10;
 }
 
 .madeby {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -18,15 +18,34 @@ const Dot = () => {
 }
 
 export const Footer = () => {
+  const makerNames = ['itjustbong', 'Hanna922', 'fecapark']
+
+  const getShuffledMakerNames = () => {
+    return makerNames.sort(() => Math.random() - 0.5)
+  }
+
+  const getShuffledNameLinks = () => {
+    const makerNames = getShuffledMakerNames()
+    const lastMakerName = makerNames[makerNames.length - 1]
+    const nameLinks = makerNames.slice(0, -1).map((makerName) => {
+      return (
+        <>
+          <NameLink href={`https://github.com/${makerName}`}>{makerName}</NameLink>
+          <Dot />
+        </>
+      )
+    })
+    nameLinks.push(
+      <NameLink href={`https://github.com/${lastMakerName}`}>{lastMakerName}</NameLink>
+    )
+    return nameLinks
+  }
+
   return (
     <footer className={styles.footer}>
       <div className={styles.madeby}>
         <span>Made by</span>
-        <NameLink href="https://github.com/itjustbong">itjustbong</NameLink>
-        <Dot />
-        <NameLink href="https://github.com/Hanna922">Hanna922</NameLink>
-        <Dot />
-        <NameLink href="https://github.com/fecapark">fecapark</NameLink>
+        {...getShuffledNameLinks()}
       </div>
     </footer>
   )

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,7 +1,33 @@
+import styles from './Footer.module.css'
+
+interface INameLinkProps {
+  href: string
+  children: React.ReactNode
+}
+
+const NameLink = ({ href, children }: INameLinkProps) => {
+  return (
+    <a className={styles['name-link']} href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  )
+}
+
+const Dot = () => {
+  return <div className={styles.dot}></div>
+}
+
 export const Footer = () => {
   return (
-    <footer>
-      <span>Made by itjustbong · Hanna922 · fecapark</span>
+    <footer className={styles.footer}>
+      <div className={styles.madeby}>
+        <span>Made by</span>
+        <NameLink href="https://github.com/itjustbong">itjustbong</NameLink>
+        <Dot />
+        <NameLink href="https://github.com/Hanna922">Hanna922</NameLink>
+        <Dot />
+        <NameLink href="https://github.com/fecapark">fecapark</NameLink>
+      </div>
     </footer>
   )
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,7 @@
+export const Footer = () => {
+  return (
+    <footer>
+      <span>Made by itjustbong · Hanna922 · fecapark</span>
+    </footer>
+  )
+}

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -10,6 +10,8 @@
 
   font-size: 1.5rem;
   padding: 1.5rem 2rem;
+
+  z-index: 100;
 }
 
 .logo {
@@ -38,11 +40,11 @@
   border-radius: 50%;
 
   background-color: #121214;
-  z-index: 9;
+  z-index: 1;
 }
 
 .icon-link {
   cursor: pointer;
   font-size: 2.25rem;
-  z-index: 10;
+  z-index: 2;
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,0 +1,6 @@
+.header {
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,6 +1,31 @@
 .header {
+  position: fixed;
+  top: 0;
+  left: 0;
+
   width: 100%;
 
   display: flex;
   justify-content: space-between;
+
+  font-size: 1.5rem;
+  padding: 1.5rem 2rem;
+}
+
+.logo {
+  /* 드래그 방지 */
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+
+  font-family: Raleway, sans-serif;
+  font-weight: 600;
+}
+
+.icon-link {
+  all: unset;
+  cursor: pointer;
+
+  font-size: 2.25rem;
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -23,9 +23,26 @@
   font-weight: 600;
 }
 
-.icon-link {
-  all: unset;
-  cursor: pointer;
+.github {
+  position: relative;
+}
 
+.mask {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate3d(-50%, -50%, 0);
+
+  width: 1px;
+  height: 1px;
+  border-radius: 50%;
+
+  background-color: #121214;
+  z-index: 9;
+}
+
+.icon-link {
+  cursor: pointer;
   font-size: 2.25rem;
+  z-index: 10;
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,15 @@
+import { IconWrapper } from '../IconWrapper/IconWrapper'
+
+import styles from './Header.module.css'
+
+export const Header = () => {
+  return (
+    <header className={styles.header}>
+      <div>
+        <span>signature</span>
+      </div>
+
+      <IconWrapper>github</IconWrapper>
+    </header>
+  )
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -12,7 +12,9 @@ export const Header = () => {
       </div>
 
       <IconWrapper>
-        <FaGithub />
+        <a href="https://github.com/gdsc-ssu/signature" target="_blank" rel="noopener noreferrer">
+          <FaGithub />
+        </a>
       </IconWrapper>
     </header>
   )

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react'
+
 import { FaGithub } from 'react-icons/fa'
 
 import { IconWrapper } from '../IconWrapper/IconWrapper'
@@ -5,22 +7,48 @@ import { IconWrapper } from '../IconWrapper/IconWrapper'
 import styles from './Header.module.css'
 
 export const Header = () => {
+  const maskRef = useRef<HTMLDivElement>(null)
+
+  const onLinkClick = () => {
+    if (!maskRef.current) return
+
+    const pixelRatio = window.devicePixelRatio > 1 ? 2 : 1
+    const stageWidth = document.body.clientWidth * pixelRatio
+    const stageHeight = window.innerHeight * pixelRatio
+    const maxRadius = Math.sqrt(stageWidth * stageWidth + stageHeight * stageHeight)
+
+    maskRef.current.style.transition = 'transform 1.2s cubic-bezier(0.83, 0, 0.17, 1)'
+
+    requestAnimationFrame(() => {
+      maskRef.current!.style.transform = `translate3d(-50%, -50%, 0) scale(${maxRadius})`
+    })
+
+    maskRef.current.ontransitionend = () => {
+      maskRef.current!.ontransitionend = null
+
+      setTimeout(() => {
+        window.open('https://github.com/gdsc-ssu/signature', '_blank')
+      }, 100)
+
+      setTimeout(() => {
+        maskRef.current!.style.transition = ''
+        maskRef.current!.style.transform = ''
+      }, 1000)
+    }
+  }
+
   return (
     <header className={styles.header}>
       <div className={styles.logo}>
         <span>signature</span>
       </div>
 
-      <IconWrapper>
-        <a
-          className={styles['icon-link']}
-          href="https://github.com/gdsc-ssu/signature"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+      <div className={styles.github} onClick={onLinkClick}>
+        <div ref={maskRef} className={styles.mask}></div>
+        <IconWrapper className={styles['icon-link']}>
           <FaGithub />
-        </a>
-      </IconWrapper>
+        </IconWrapper>
+      </div>
     </header>
   )
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -8,7 +8,7 @@ export const Header = () => {
   return (
     <header className={styles.header}>
       <div className={styles.logo}>
-        <span>signature .</span>
+        <span>signature</span>
       </div>
 
       <IconWrapper>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,12 +7,17 @@ import styles from './Header.module.css'
 export const Header = () => {
   return (
     <header className={styles.header}>
-      <div>
-        <span>signature</span>
+      <div className={styles.logo}>
+        <span>signature .</span>
       </div>
 
       <IconWrapper>
-        <a href="https://github.com/gdsc-ssu/signature" target="_blank" rel="noopener noreferrer">
+        <a
+          className={styles['icon-link']}
+          href="https://github.com/gdsc-ssu/signature"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <FaGithub />
         </a>
       </IconWrapper>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,3 +1,5 @@
+import { FaGithub } from 'react-icons/fa'
+
 import { IconWrapper } from '../IconWrapper/IconWrapper'
 
 import styles from './Header.module.css'
@@ -9,7 +11,9 @@ export const Header = () => {
         <span>signature</span>
       </div>
 
-      <IconWrapper>github</IconWrapper>
+      <IconWrapper>
+        <FaGithub />
+      </IconWrapper>
     </header>
   )
 }

--- a/src/components/IconWrapper/IconWrapper.module.css
+++ b/src/components/IconWrapper/IconWrapper.module.css
@@ -1,0 +1,5 @@
+.wrapper {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/components/IconWrapper/IconWrapper.tsx
+++ b/src/components/IconWrapper/IconWrapper.tsx
@@ -1,0 +1,10 @@
+import styles from './IconWrapper.module.css'
+
+interface IIconWrapperProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export const IconWrapper = ({ children, className = '' }: IIconWrapperProps) => {
+  return <div className={`${styles.wrapper} ${className}`}>{children}</div>
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,18 @@
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+* {
+  margin: 0;
+  padding: 0;
+  outline: 0;
+
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  font-size: 16px;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  background-color: #f4f4f4;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -9,10 +9,12 @@
 html,
 body {
   width: 100%;
+
   font-size: 16px;
   font-weight: 400;
 }
 
 body {
+  color: #121214;
   background-color: #f4f4f4;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom/client'
 
 import { App } from './App'
 
+import './index.css'
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,6 +2301,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-icons@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.12.0.tgz#54806159a966961bfd5cdb26e492f4dafd6a8d78"
+  integrity sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
### 패키지 추가
- `react-icons`

### Google Fonts 추가

- `index.html` 파일에 Google Font 사용을 위한 `link` 태그 적용
- Raleway, Noto Sans 폰트 추가

### 레이아웃 추가

- Header
- Footer

### 기능

- Footer의 깃허브 프로필명을 클릭하면 해당 깃허브 프로필로 이동하는 기능
- 새로고침시 마다 프로필명 순서 랜덤하게 변경되는 기능
- Header의 깃허브 아이콘을 클릭하면 트랜지션과 함께 새 창에서 레포지토리로 이동하는 기능