### PR TITLE
fix: early hand tracking initiation bug

### DIFF
--- a/src/components/HandTrack/HandTrack.tsx
+++ b/src/components/HandTrack/HandTrack.tsx
@@ -27,6 +27,7 @@ export const HandTrack = () => {
   }, [])
 
   useAnimationFrame(async () => {
+    if (!tracker.current) return
     const hands = (await tracker.current.estimateHands($video.current, {
       flipHorizontal: true,
     })) as Array<HandPoint>


### PR DESCRIPTION
## 구현 사항

- Added a null check for the hand tracker instance before initializing loading hand tracking model.