### PR TITLE
Feat/drawing animation

### DIFF
--- a/src/components/SnapScrollItem/SnapScrollItem1.tsx
+++ b/src/components/SnapScrollItem/SnapScrollItem1.tsx
@@ -1,15 +1,39 @@
 import { useEffect, useRef } from 'react'
 
-import { init } from '@/components/TextDrawing/TextDrawing'
+import { Init, TextDrawing } from '@/components/TextDrawing/TextDrawing'
 
 export const SnapScrollItem1 = ({ id }: { id: string }) => {
+  const containerRef = useRef<HTMLDivElement>(null)
   const isRender = useRef<boolean>(false)
 
   useEffect(() => {
-    if (isRender.current) return
-    isRender.current = true
-    init(id)
-  }, [])
+    const observerCallback: IntersectionObserverCallback = (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          // Check if this is the first render
+          if (!isRender.current) {
+            isRender.current = true
+            Init(id)
+          } else {
+            // Re-trigger the animation
+            TextDrawing()
+          }
+        }
+      })
+    }
 
-  return <div style={{ height: '100%' }} id={id} />
+    // Setting up the Intersection Observer
+    const observer = new IntersectionObserver(observerCallback, {
+      threshold: 0.1,
+    })
+
+    // Observing the current element
+    if (containerRef.current) {
+      observer.observe(containerRef.current)
+    }
+
+    return () => observer.disconnect()
+  }, [id])
+
+  return <div ref={containerRef} style={{ height: '100%' }} id={id} />
 }

--- a/src/components/TextDrawing/TextDrawing.tsx
+++ b/src/components/TextDrawing/TextDrawing.tsx
@@ -7,7 +7,7 @@ const sw = window.innerWidth
 const sh = window.innerHeight
 const pixelRatio = 2
 
-export function init(id: string) {
+export const Init = (id: string) => {
   canvas = document.createElement('canvas')
 
   canvas.style.top = '0'
@@ -24,6 +24,24 @@ export function init(id: string) {
   canvas.style.height = sh + 'px'
   ctx.scale(pixelRatio, pixelRatio)
 
+  requestAnimationFrame(animate)
+
+  TextDrawing()
+}
+
+const animate = () => {
+  requestAnimationFrame(animate)
+
+  ctx.clearRect(0, 0, sw, sh)
+
+  const x = (sw - leon.rect.w) / 2
+  const y = (sh - leon.rect.h) / 2
+  leon.position(x, y)
+
+  leon.draw(ctx)
+}
+
+export const TextDrawing = () => {
   leon = new LeonSans({
     text: 'signature',
     color: ['#000000'],
@@ -31,11 +49,8 @@ export function init(id: string) {
     weight: 200,
   })
 
-  requestAnimationFrame(animate)
-
-  let i
   const total = leon.drawing.length
-  for (i = 0; i < total; i++) {
+  for (let i = 0; i < total; i++) {
     TweenMax.fromTo(
       leon.drawing[i],
       1.6,
@@ -49,16 +64,4 @@ export function init(id: string) {
       }
     )
   }
-}
-
-function animate() {
-  requestAnimationFrame(animate)
-
-  ctx.clearRect(0, 0, sw, sh)
-
-  const x = (sw - leon.rect.w) / 2
-  const y = (sh - leon.rect.h) / 2
-  leon.position(x, y)
-
-  leon.draw(ctx)
 }

--- a/src/components/TextDrawing/TextDrawing.tsx
+++ b/src/components/TextDrawing/TextDrawing.tsx
@@ -1,32 +1,32 @@
 import LeonSans from '@nindaff/leonsans'
 import { TweenMax } from 'gsap'
 
-let leon: any, canvas, ctx: CanvasRenderingContext2D
+let leon: any, canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D
 
-const sw = window.innerWidth
-const sh = window.innerHeight
+let sw = window.innerWidth
+let sh = window.innerHeight
 const pixelRatio = 2
 
 export const Init = (id: string) => {
   canvas = document.createElement('canvas')
 
-  canvas.style.top = '0'
-  canvas.style.left = '0'
-  canvas.style.width = '100%'
-  canvas.style.height = '100%'
-
   document.getElementById(id)?.appendChild(canvas)
   ctx = canvas.getContext('2d') as CanvasRenderingContext2D
 
+  onResize()
+  requestAnimationFrame(animate)
+  TextDrawing()
+  window.addEventListener('resize', onResize)
+}
+
+const onResize = () => {
+  sw = window.innerWidth
+  sh = window.innerHeight
   canvas.width = sw * pixelRatio
   canvas.height = sh * pixelRatio
   canvas.style.width = sw + 'px'
   canvas.style.height = sh + 'px'
   ctx.scale(pixelRatio, pixelRatio)
-
-  requestAnimationFrame(animate)
-
-  TextDrawing()
 }
 
 const animate = () => {

--- a/src/components/TextDrawing/TextDrawing.tsx
+++ b/src/components/TextDrawing/TextDrawing.tsx
@@ -5,7 +5,6 @@ let leon: any, canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D
 
 let sw = window.innerWidth
 let sh = window.innerHeight
-const pixelRatio = 2
 
 export const Init = (id: string) => {
   canvas = document.createElement('canvas')
@@ -20,6 +19,7 @@ export const Init = (id: string) => {
 }
 
 const onResize = () => {
+  const pixelRatio = window.devicePixelRatio > 1 ? 2 : 1
   sw = window.innerWidth
   sh = window.innerHeight
   canvas.width = sw * pixelRatio


### PR DESCRIPTION
IntersectionObserverCallback을 활용해서 스크롤 후에 다시 1번 화면으로 돌아왔을 때 애니메이션이 재실행되도록 구현했습니다.
=> 추후에 해당 로직이 재사용된다면 공통 로직으로 분리할게요
onResize 함수를 추가해서 윈도우 사이즈가 변경되면 캔버스 사이즈가 변경되도록 했습니다.

https://github.com/gdsc-ssu/signature/assets/84809236/330f6633-615b-46a0-8d87-d5c176ffd0fa


